### PR TITLE
move PropTypes from react to prop-types package

### DIFF
--- a/DateField/DatePickerAndroid.js
+++ b/DateField/DatePickerAndroid.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import moment from 'moment'
 import PickerAndroid from './PickerAndroid'
 
@@ -17,14 +18,14 @@ const DatePickerAndroid = ({androidStyles, date, formatDay, formatMonth, maximum
 )
 
 DatePickerAndroid.propTypes = {
-  androidStyles: React.PropTypes.object,
-  date: React.PropTypes.instanceOf(Date),
-  formatDay: React.PropTypes.func,
-  formatMonth: React.PropTypes.func,
-  locale: React.PropTypes.object,
-  mode: React.PropTypes.string,
-  minimumDate: React.PropTypes.object,
-  onDateChange: React.PropTypes.func.isRequired,
+  androidStyles: PropTypes.object,
+  date: PropTypes.instanceOf(Date),
+  formatDay: PropTypes.func,
+  formatMonth: PropTypes.func,
+  locale: PropTypes.object,
+  mode: PropTypes.string,
+  minimumDate: PropTypes.object,
+  onDateChange: PropTypes.func.isRequired,
 }
 
 DatePickerAndroid.defaultProps = {

--- a/DateField/index.js
+++ b/DateField/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {
   View,
   DatePickerIOS,
@@ -79,12 +80,12 @@ class DateInput extends React.Component {
 }
 
 DateInput.propTypes = {
-  androidStyles: React.PropTypes.object,
-  selectedValue: React.PropTypes.oneOfType([React.PropTypes.instanceOf(Date), React.PropTypes.number, React.PropTypes.string]),
-  mode: React.PropTypes.string,
-  minDate: React.PropTypes.instanceOf(Date),
-  maxDate: React.PropTypes.instanceOf(Date),
-  onValueChange: React.PropTypes.func.isRequired,
+  androidStyles: PropTypes.object,
+  selectedValue: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
+  mode: PropTypes.string,
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date),
+  onValueChange: PropTypes.func.isRequired,
 }
 
 DateInput.defaultProps = {

--- a/MapField/GeolocateInput.js
+++ b/MapField/GeolocateInput.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { View } from 'react-native'
 import MapView from 'react-native-maps'
 
@@ -114,16 +115,16 @@ class GeolocateInput extends React.Component {
 }
 
 GeolocateInput.propTypes = {
-  allowScroll: React.PropTypes.bool,
-  value: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
-  liteMode: React.PropTypes.bool,
-  region: React.PropTypes.shape({
-    latitude: React.PropTypes.number,
-    longitude: React.PropTypes.number,
+  allowScroll: PropTypes.bool,
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  liteMode: PropTypes.bool,
+  region: PropTypes.shape({
+    latitude: PropTypes.number,
+    longitude: PropTypes.number,
   }),
-  styles: React.PropTypes.object,
-  onLocationSet: React.PropTypes.func,
+  styles: PropTypes.object,
+  onLocationSet: PropTypes.func,
 }
 
 GeolocateInput.defaultProps = {

--- a/MapField/index.js
+++ b/MapField/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {
   View,
   ScrollView,
@@ -179,15 +180,15 @@ class MapField extends React.Component {
 }
 
 MapField.propTypes = {
-  customStyles: React.PropTypes.object,
-  googlePlaceKey: React.PropTypes.string.isRequired,
-  field: React.PropTypes.string.isRequired,
-  address: React.PropTypes.string,
-  coords: React.PropTypes.object,
-  onChange: React.PropTypes.func.isRequired,
-  liteMode: React.PropTypes.bool,
-  placeholder: React.PropTypes.string,
-  pinImage: React.PropTypes.any,
+  customStyles: PropTypes.object,
+  googlePlaceKey: PropTypes.string.isRequired,
+  field: PropTypes.string.isRequired,
+  address: PropTypes.string,
+  coords: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  liteMode: PropTypes.bool,
+  placeholder: PropTypes.string,
+  pinImage: PropTypes.any,
 }
 
 MapField.defaultProps = {

--- a/SuggestField/index.js
+++ b/SuggestField/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import {
   View,
   ScrollView,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-field-components",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Set of useful component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When upgrading to react native  > 0.48 we get problems with react prop types #2

I tested this changes in my project and it's work.